### PR TITLE
Dynamically allocated vertex buffer

### DIFF
--- a/r3d.c
+++ b/r3d.c
@@ -47,15 +47,17 @@ int r3d_clip(r3d_poly *poly, r3d_plane *planes, r3d_int nplanes) {
 	r3d_int *nverts = &poly->nverts;
 	if (*nverts <= 0) return 0;
 
+        int *maxverts = &poly->maxverts;  /* size of vertex buffer */
+        
 	// variable declarations
 	r3d_int v, p, np, onv, vcur, vnext, vstart, pnext, numunclipped;
 
 	// signed distances to the clipping plane
-	r3d_real sdists[R3D_MAX_VERTS];
+	r3d_real *sdists = (r3d_real *) malloc((*maxverts)*sizeof(r3d_real));
 	r3d_real smin, smax;
 
 	// for marking clipped vertices
-	r3d_int clipped[R3D_MAX_VERTS];
+	r3d_int *clipped = (r3d_int *) malloc((*maxverts)*sizeof(r3d_int));
 
 	// loop over each clip plane
 	for (p = 0; p < nplanes; ++p) {
@@ -63,7 +65,7 @@ int r3d_clip(r3d_poly *poly, r3d_plane *planes, r3d_int nplanes) {
 		onv = *nverts;
 		smin = 1.0e30;
 		smax = -1.0e30;
-		memset(&clipped, 0, sizeof(clipped));
+		memset(clipped, 0, (*maxverts)*sizeof(r3d_int));
 		for (v = 0; v < onv; ++v) {
 			sdists[v] = planes[p].d + dot(vertbuffer[v].pos, planes[p].n);
 			if (sdists[v] < smin) smin = sdists[v];
@@ -75,6 +77,8 @@ int r3d_clip(r3d_poly *poly, r3d_plane *planes, r3d_int nplanes) {
 		if (smin >= 0.0) continue;
 		if (smax <= 0.0) {
 			*nverts = 0;
+                        free(sdists);
+                        free(clipped);
 			return 1;
 		}
 
@@ -84,11 +88,14 @@ int r3d_clip(r3d_poly *poly, r3d_plane *planes, r3d_int nplanes) {
 			for (np = 0; np < 3; ++np) {
 				vnext = vertbuffer[vcur].pnbrs[np];
 				if (!clipped[vnext]) continue;
-                                if (*nverts == R3D_MAX_VERTS) {
-#if !defined(NDEBUG)                                  
-                                  fprintf(stderr, "r3d_clip: Max vertex buffer size exceeded; Increase R3D_MAX_VERTS");
-#endif
-                                  return 0;
+                                
+                                if (*nverts == *maxverts) {
+                                  *maxverts *= 2;
+                                  vertbuffer = (r3d_vertex *) realloc(vertbuffer, *maxverts*sizeof(r3d_vertex));
+                                  poly->verts = vertbuffer;
+                                  clipped = (r3d_int *) realloc(clipped, *maxverts*sizeof(r3d_int));
+                                  memset(clipped + (*nverts), 0, (*maxverts - *nverts)*sizeof(r3d_int));
+                                  sdists = (r3d_real *) realloc(sdists, *maxverts*sizeof(r3d_real));
                                 }
 				vertbuffer[*nverts].pnbrs[0] = vcur;
 				vertbuffer[vcur].pnbrs[np] = *nverts;
@@ -129,6 +136,9 @@ int r3d_clip(r3d_poly *poly, r3d_plane *planes, r3d_int nplanes) {
 				vertbuffer[v].pnbrs[np] = clipped[vertbuffer[v].pnbrs[np]];
 	}
 
+        free(sdists);
+        free(clipped);
+
         return 1;
 }
 
@@ -137,26 +147,33 @@ int r3d_split(r3d_poly *inpolys, r3d_int npolys, r3d_plane plane,
 	// direct access to vertex buffer
 	r3d_int v, np, npnxt, onv, vcur, vnext, vstart, pnext, nright, cside, p;
 	r3d_rvec3 newpos;
-	r3d_int side[R3D_MAX_VERTS];
-	r3d_real sdists[R3D_MAX_VERTS];
-	r3d_int *nverts;
+	r3d_int *side;
+	r3d_real *sdists;
+	r3d_int *nverts, *maxverts;
 	r3d_vertex *vertbuffer;
 	r3d_poly *outpolys[2];
 
+        int sidesz = 0;
+        for (p = 0; p < npolys; ++p)
+                if (sidesz < inpolys[p].nverts) sidesz = inpolys[p].nverts;
+        side = (r3d_int *) malloc(sidesz*sizeof(r3d_int));
+        sdists = (r3d_real *) malloc(sidesz*sizeof(r3d_real));
+        
 	for (p = 0; p < npolys; ++p) {
+                memset(side, 0, sidesz*sizeof(r3d_int));
 		nverts = &inpolys[p].nverts;
+                maxverts = &inpolys[p].maxverts;
 		vertbuffer = inpolys[p].verts;
 		outpolys[0] = &out_pos[p];
 		outpolys[1] = &out_neg[p];
 		if (*nverts <= 0) {
-			memset(&out_pos[p], 0, sizeof(r3d_poly));
-			memset(&out_neg[p], 0, sizeof(r3d_poly));
+                        r3d_init_blank(&out_pos[p], 0);
+                        r3d_init_blank(&out_neg[p], 0);
 			continue;
 		}
 
 		// calculate signed distances to the clip plane
 		nright = 0;
-		memset(&side, 0, sizeof(side));
 		for (v = 0; v < *nverts; ++v) {
 			sdists[v] = plane.d + dot(vertbuffer[v].pos, plane.n);
 			if (sdists[v] < 0.0) {
@@ -167,13 +184,13 @@ int r3d_split(r3d_poly *inpolys, r3d_int npolys, r3d_plane plane,
 
 		// return if the poly lies entirely on one side of it
 		if (nright == 0) {
-			out_pos[p] = inpolys[p];
-			memset(&out_neg[p], 0, sizeof(r3d_poly));
+                        r3d_copy(&out_pos[p], &inpolys[p]);
+			r3d_init_blank(&out_neg[p], 0);
 			continue;
 		}
 		if (nright == *nverts) {
-			out_neg[p] = inpolys[p];
-			memset(&out_pos[p], 0, sizeof(r3d_poly));
+                        r3d_copy(&out_neg[p], &inpolys[p]);
+                        r3d_init_blank(&out_pos[p], 0);
 			continue;
 		}
 
@@ -186,28 +203,34 @@ int r3d_split(r3d_poly *inpolys, r3d_int npolys, r3d_plane plane,
 				if (!side[vnext]) continue;
 				wav(vertbuffer[vcur].pos, -sdists[vnext], vertbuffer[vnext].pos,
 						sdists[vcur], newpos);
-                                if (*nverts == R3D_MAX_VERTS) {
-#if !defined(NDEBUG)                                  
-                                  fprintf(stderr, "r3d_split: Max vertex buffer size exceeded; Increase R3D_MAX_VERTS");
-#endif                                  
-                                  return 0;
+
+                                if ((*nverts)+2 > *maxverts) { // expand buffer
+                                        *maxverts *= 2;
+                                        vertbuffer = (r3d_vertex *) realloc(vertbuffer, (*maxverts)*sizeof(r3d_vertex));
+                                        if (!vertbuffer) return 0;
+                                        inpolys[p].verts = vertbuffer;
                                 }
+                                if (sidesz < *maxverts) { // expand sides array
+                                        side = (r3d_int *) realloc(side, (*maxverts)*sizeof(r3d_int));
+                                        if (!side) return 0;
+                                        int diff = (*maxverts)-sidesz;
+                                        memset(side + sidesz, 0, diff*sizeof(r3d_int));
+                                        sidesz = *maxverts;
+                                }
+                                
 				vertbuffer[*nverts].pos = newpos;
 				vertbuffer[*nverts].pnbrs[0] = vcur;
 				vertbuffer[vcur].pnbrs[np] = *nverts;
 				(*nverts)++;
-                                if (*nverts == R3D_MAX_VERTS) {
-#if !defined(NDEBUG)                                  
-                                  fprintf(stderr, "r3d_split: Max vertex buffer size exceeded; Increase R3D_MAX_VERTS");
-#endif                                  
-                                  return 0;
-                                }
+
 				vertbuffer[*nverts].pos = newpos;
 				side[*nverts] = 1;
+                                nright++;
 				vertbuffer[*nverts].pnbrs[0] = vnext;
 				for (npnxt = 0; npnxt < 3; ++npnxt)
 					if (vertbuffer[vnext].pnbrs[npnxt] == vcur) break;
 				vertbuffer[vnext].pnbrs[npnxt] = *nverts;
+
 				(*nverts)++;
 			}
 		}
@@ -230,9 +253,9 @@ int r3d_split(r3d_poly *inpolys, r3d_int npolys, r3d_plane plane,
 
 		// copy and compress vertices into their new buffers reusing side[] for
 		// reindexing
+                r3d_init_blank(outpolys[0], (*nverts-nright));
+                r3d_init_blank(outpolys[1], nright);
 		onv = *nverts;
-		outpolys[0]->nverts = 0;
-		outpolys[1]->nverts = 0;
 		for (v = 0; v < onv; ++v) {
 			cside = side[v];
 			outpolys[cside]->verts[outpolys[cside]->nverts] = vertbuffer[v];
@@ -247,7 +270,10 @@ int r3d_split(r3d_poly *inpolys, r3d_int npolys, r3d_plane plane,
 				outpolys[1]->verts[v].pnbrs[np] = side[outpolys[1]->verts[v].pnbrs[np]];
 	}
 
-        return 0;
+        free(side);
+        free(sdists);
+
+        return 1;
 }
 
 void r3d_reduce(r3d_poly *poly, r3d_real *moments, r3d_int polyorder) {
@@ -475,18 +501,23 @@ r3d_rvec3 r3d_poly_center(r3d_poly* poly) {
 
 r3d_int r3d_is_good(r3d_poly *poly) {
 	r3d_int v, np, rcur;
-	r3d_int nvstack;
+	r3d_int nvstack, maxstack;
 	r3d_int va, vb, vc;
-	r3d_int vct[R3D_MAX_VERTS];
-	r3d_int stack[R3D_MAX_VERTS];
-	r3d_int regions[R3D_MAX_VERTS];
+	r3d_int *vct;
+	r3d_int *stack;
+	r3d_int *regions;
 
 	// direct access to vertex buffer
 	r3d_vertex *vertbuffer = poly->verts;
 	r3d_int *nverts = &poly->nverts;
 
+        vct = (r3d_int *) calloc(*nverts, sizeof(r3d_int));
+        regions = (r3d_int *) calloc(*nverts, sizeof(r3d_int));
+
+        maxstack = *nverts;
+        stack = (r3d_int *) calloc(maxstack, sizeof(r3d_int));
+
 	// consistency check
-	memset(&vct, 0, sizeof(vct));
 	for (v = 0; v < *nverts; ++v) {
 		// return false if two vertices are connected by more than one edge or if
 		// any edges are obviously invalid
@@ -520,7 +551,6 @@ r3d_int r3d_is_good(r3d_poly *poly) {
 	// Flood-fill starting from each vertex to give each connected region a unique
 	// ID.
 	rcur = 1;
-	memset(&regions, 0, sizeof(regions));
 	for (v = 0; v < *nverts; ++v) {
 		if (regions[v]) continue;
 		nvstack = 0;
@@ -529,6 +559,10 @@ r3d_int r3d_is_good(r3d_poly *poly) {
 			vc = stack[--nvstack];
 			if (regions[vc]) continue;
 			regions[vc] = rcur;
+                        if (nvstack + 3 >= maxstack) {
+                          maxstack *= 2;
+                          stack = (r3d_int *) realloc(stack, maxstack*sizeof(r3d_int));
+                        }
 			stack[nvstack++] = vertbuffer[vc].pnbrs[0];
 			stack[nvstack++] = vertbuffer[vc].pnbrs[1];
 			stack[nvstack++] = vertbuffer[vc].pnbrs[2];
@@ -549,7 +583,7 @@ r3d_int r3d_is_good(r3d_poly *poly) {
 				if (regions[vc] == rcur && vc != va && vc != vb) break;
 
 			// use vct to mark visited verts mask out va and vb
-			memset(&vct, 0, sizeof(vct));
+			memset(vct, 0, (*nverts)*sizeof(r3d_int));
 			vct[va] = 1;
 			vct[vb] = 1;
 
@@ -576,6 +610,9 @@ r3d_int r3d_is_good(r3d_poly *poly) {
 		}
 	}
 
+        free(vct);
+        free(stack);
+        free(regions);
 	return 1;
 }
 
@@ -641,7 +678,39 @@ void r3d_affine(r3d_poly *poly, r3d_real mat[4][4]) {
 	}
 }
 
-void r3d_init_tet(r3d_poly *poly, r3d_rvec3 verts[4]) {
+int r3d_init_blank(r3d_poly *poly, r3d_int nvalloc) {
+        poly->nverts = 0;
+        poly->maxverts = nvalloc;
+        if (nvalloc == 0)
+                poly->verts = NULL;
+        else {
+                poly->verts = (r3d_vertex *) malloc(nvalloc*sizeof(r3d_vertex));
+                if (!poly->verts) return 0;
+        }
+        return 1;
+}
+
+int r3d_copy(r3d_poly *destpoly, r3d_poly *srcpoly) {
+        // Can't truly know if destpoly is initialized, so initialize it 
+        if (!r3d_init_blank(destpoly, srcpoly->maxverts))
+                return 0;
+        memcpy(destpoly->verts, srcpoly->verts, srcpoly->maxverts*sizeof(r3d_vertex));
+        destpoly->nverts = srcpoly->nverts;
+        return 1;
+}
+
+void r3d_free(r3d_poly *poly) {
+        if (poly->verts) free(poly->verts);
+        poly->verts = NULL;
+        poly->maxverts = 0;
+        poly->nverts = 0;
+}
+
+int r3d_init_tet(r3d_poly *poly, r3d_rvec3 verts[4]) {
+        // initialize poly
+        if (!r3d_init_blank(poly, 4))
+                return 0;
+  
 	// direct access to vertex buffer
 	r3d_vertex *vertbuffer = poly->verts;
 	r3d_int *nverts = &poly->nverts;
@@ -664,9 +733,15 @@ void r3d_init_tet(r3d_poly *poly, r3d_rvec3 verts[4]) {
 	// copy vertex coordinates
 	r3d_int v;
 	for (v = 0; v < 4; ++v) vertbuffer[v].pos = verts[v];
+
+        return 1;
 }
 
-void r3d_init_box(r3d_poly *poly, r3d_rvec3 rbounds[2]) {
+int r3d_init_box(r3d_poly *poly, r3d_rvec3 rbounds[2]) {
+        // initialize poly
+        if (!r3d_init_blank(poly, 8))
+                return 0;
+  
 	// direct access to vertex buffer
 	r3d_vertex *vertbuffer = poly->verts;
 	r3d_int *nverts = &poly->nverts;
@@ -720,30 +795,29 @@ void r3d_init_box(r3d_poly *poly, r3d_rvec3 rbounds[2]) {
 	vertbuffer[7].pos.x = rbounds[0].x;
 	vertbuffer[7].pos.y = rbounds[1].y;
 	vertbuffer[7].pos.z = rbounds[1].z;
+
+        return 1;
 }
 
 int r3d_init_poly(r3d_poly *poly, r3d_rvec3 *vertices, r3d_int numverts,
 									 r3d_int **faceinds, r3d_int *numvertsperface,
 									 r3d_int numfaces) {
+        // initialize poly
+        if (!r3d_init_blank(poly, numverts))
+                return 0;
+  
 	// dummy vars
 	r3d_int v, vprev, vcur, vnext, f, np;
 
-        if (numverts > R3D_MAX_VERTS) {
-#if !defined(NDEBUG)
-          fprintf(stderr, "r3d_init_poly: Max vertex buffer size exceeded; Increase R3D_MAX_VERTS");
-#endif
-          return 0;
-        }
-        
 	// direct access to vertex buffer
 	r3d_vertex *vertbuffer = poly->verts;
 	r3d_int *nverts = &poly->nverts;        
-        
+        r3d_int *maxverts = &poly->maxverts;
+
 	// count up the number of faces per vertex and act accordingly
-	r3d_int eperv[R3D_MAX_VERTS];
-	r3d_int minvperf = R3D_MAX_VERTS;
+	r3d_int *eperv = (r3d_int *) calloc((*maxverts), sizeof(r3d_int));
+	r3d_int minvperf = 9999;
 	r3d_int maxvperf = 0;
-	memset(&eperv, 0, sizeof(eperv));
 	for (f = 0; f < numfaces; ++f)
 		for (v = 0; v < numvertsperface[f]; ++v) ++eperv[faceinds[f][v]];
 	for (v = 0; v < numverts; ++v) {
@@ -755,7 +829,10 @@ int r3d_init_poly(r3d_poly *poly, r3d_rvec3 *vertices, r3d_int numverts,
 	*nverts = 0;
 
 	// return if we were given an invalid poly
-	if (minvperf < 3) return 0;
+	if (minvperf < 3) {
+                return 0;
+                free(eperv);
+        }
 
 	if (maxvperf == 3) {
 		// simple case with no need for duplicate vertices
@@ -764,7 +841,7 @@ int r3d_init_poly(r3d_poly *poly, r3d_rvec3 *vertices, r3d_int numverts,
 		*nverts = numverts;
 		for (v = 0; v < *nverts; ++v) {
 			vertbuffer[v].pos = vertices[v];
-			for (np = 0; np < 3; ++np) vertbuffer[v].pnbrs[np] = R3D_MAX_VERTS;
+			for (np = 0; np < 3; ++np) vertbuffer[v].pnbrs[np] = 9999;
 		}
 
 		// build graph connectivity by correctly orienting half-edges for each
@@ -792,39 +869,95 @@ int r3d_init_poly(r3d_poly *poly, r3d_rvec3 *vertices, r3d_int numverts,
 	} else {
 		// we need to create duplicate, degenerate vertices to account for more than
 		// three edges per vertex. This is complicated.
-
+          
 		r3d_int tface = 0;
 		for (v = 0; v < numverts; ++v) tface += eperv[v];
 
 		// need more variables
 		r3d_int v0, v1, v00, v11, numunclipped;
 
+                // Right away let's double the allocated buffer sizes
+                vertbuffer = (r3d_vertex *) realloc(vertbuffer, 2*(*maxverts)*sizeof(r3d_vertex));
+                if (!vertbuffer) return 0;
+                poly->verts = vertbuffer;
+                
+                eperv = (r3d_int *) realloc(eperv, 2*(*maxverts)*sizeof(r3d_int));
+                if (!eperv) return 0;
+                memset(eperv+(*maxverts), 0, (*maxverts)*sizeof(r3d_int));
+
+                *maxverts *= 2;
+                
+                
 		// we need a few extra buffers to handle the necessary operations
-		r3d_vertex vbtmp[3 * R3D_MAX_VERTS];
-		r3d_int util[3 * R3D_MAX_VERTS];
-		r3d_int vstart[R3D_MAX_VERTS];
+                
+		r3d_vertex *vbtmp = (r3d_vertex *) malloc(3*(*maxverts)*sizeof(r3d_vertex));
+                if (!vbtmp) {
+                        free(eperv);
+                        return 0;
+                }
+                r3d_int *util = (r3d_int *) malloc(3*(*maxverts)*sizeof(r3d_int));
+                if (!util) {
+                        free(eperv);
+                        free(vbtmp);
+                        return 0;
+                }
+		r3d_int *vstart = (r3d_int *) malloc((*maxverts)*sizeof(r3d_int));
+                if (!vstart) {
+                        free(eperv);
+                        free(vbtmp);
+                        free(util);
+                        return 0;
+                }
 
 		// build vertex mappings to degenerate duplicates and read in vertex
 		// locations
 		*nverts = 0;
 		for (v = 0; v < numverts; ++v) {
-                        if ((*nverts) + eperv[v] > R3D_MAX_VERTS) {
-#if !defined(NDEBUG)
-                          fprintf(stderr, "r3d_init_poly: Max vertex buffer size exceeded; Increase R3D_MAX_VERTS");
-#endif
-                          return 0;
+                        if ((*nverts) + eperv[v] > *maxverts) {
+                          vertbuffer = (r3d_vertex *) realloc(vertbuffer, 2*(*maxverts)*sizeof(r3d_vertex));
+                          poly->verts = vertbuffer;
+                          if (!vertbuffer) {
+                                  free(eperv);
+                                  free(vbtmp);
+                                  free(util);
+                                  free(vstart);                            
+                                  return 0;
+                          }
+                          eperv = (r3d_int *) realloc(eperv, 2*(*maxverts)*sizeof(r3d_vertex));
+                          if (!eperv) {
+                                  free(vbtmp);
+                                  free(util);
+                                  free(vstart);
+                                  return 0;
+                          }
+                          memset(eperv+(*maxverts), 0, (*maxverts)*sizeof(r3d_vertex));
+                          
+                          vbtmp = (r3d_vertex *) realloc(vbtmp, 2*3*(*maxverts)*sizeof(r3d_vertex));
+                          if (!vbtmp) {
+                                  free(util);
+                                  free(vstart);
+                                  return 0;
+                          }
+                          util = (r3d_int *) realloc(util, 2*3*(*maxverts)*sizeof(r3d_int));
+                          if (!util) {
+                                  free(vstart);
+                                  return 0;
+                          }
+                          vstart = (r3d_int *) realloc(vstart, 2*(*maxverts)*sizeof(r3d_int));
+                          if (!vstart) return 0;
+                          *maxverts *= 2;
                         }
         
 			vstart[v] = *nverts;
 			for (vcur = 0; vcur < eperv[v]; ++vcur) {
 				vbtmp[*nverts].pos = vertices[v];
-				for (np = 0; np < 3; ++np) vbtmp[*nverts].pnbrs[np] = R3D_MAX_VERTS;
+				for (np = 0; np < 3; ++np) vbtmp[*nverts].pnbrs[np] = 9999;
 				++(*nverts);
 			}
 		}
 
 		// fill in connectivity for all duplicates
-		memset(&util, 0, sizeof(util));
+		memset(util, 0, (*maxverts)*sizeof(r3d_int));
 		for (f = 0; f < numfaces; ++f) {
 			for (v = 0; v < numvertsperface[f]; ++v) {
 				vprev = faceinds[f][v];
@@ -840,7 +973,7 @@ int r3d_init_poly(r3d_poly *poly, r3d_rvec3 *vertices, r3d_int numverts,
 
 		// link degenerate duplicates, putting them in the correct order use util to
 		// mark and avoid double-processing verts
-		memset(&util, 0, sizeof(util));
+		memset(util, 0, (*maxverts)*sizeof(r3d_int));
 		for (v = 0; v < numverts; ++v) {
 			for (v0 = vstart[v]; v0 < vstart[v] + eperv[v]; ++v0) {
 				for (v1 = vstart[v]; v1 < vstart[v] + eperv[v]; ++v1) {
@@ -854,7 +987,7 @@ int r3d_init_poly(r3d_poly *poly, r3d_rvec3 *vertices, r3d_int numverts,
 		}
 
 		// complete vertex pairs
-		memset(&util, 0, sizeof(util));
+		memset(util, 0, (*maxverts)*sizeof(r3d_int));
 		for (v0 = 0; v0 < numverts; ++v0)
 			for (v1 = v0 + 1; v1 < numverts; ++v1) {
 				for (v00 = vstart[v0]; v00 < vstart[v0] + eperv[v0]; ++v00)
@@ -870,7 +1003,7 @@ int r3d_init_poly(r3d_poly *poly, r3d_rvec3 *vertices, r3d_int numverts,
 			}
 
 		// remove unnecessary dummy vertices
-		memset(&util, 0, sizeof(util));
+		memset(util, 0, (*maxverts)*sizeof(r3d_int));
 		for (v = 0; v < numverts; ++v) {
 			v0 = vstart[v];
 			v1 = vbtmp[v0].pnbrs[0];
@@ -900,8 +1033,12 @@ int r3d_init_poly(r3d_poly *poly, r3d_rvec3 *vertices, r3d_int numverts,
 		for (v = 0; v < *nverts; ++v)
 			for (np = 0; np < 3; ++np)
 				vertbuffer[v].pnbrs[np] = util[vertbuffer[v].pnbrs[np]];
+                free(vbtmp);
+                free(util);
+                free(vstart);
 	}
 
+        free(eperv);
         return 1;
 }
 
@@ -1054,7 +1191,7 @@ void r3d_print(r3d_poly *poly) {
 	}
 }
 
-void r3d_init_brep(r3d_poly *poly, r3d_brep **brep, r3d_int *numcomponents) {
+void r3d_init_brep(r3d_poly *poly, r3d_brep ***brep, r3d_int *numcomponents) {
 	// constants
 	r3d_int nverts = poly->nverts;
 
@@ -1085,17 +1222,21 @@ void r3d_init_brep(r3d_poly *poly, r3d_brep **brep, r3d_int *numcomponents) {
 		}
 	}
 
-	// arrays for marking, using C99 initializer lists instead of memset
-	r3d_int vert_marked[R3D_MAX_VERTS] = {0};
-	r3d_int edge_marked[R3D_MAX_VERTS][3] = {0};
+	// arrays for marking
+        int maxsize = nverts;
+	r3d_int *vert_marked = (r3d_int *) calloc(maxsize, sizeof(r3d_int));
+	r3d_int (*edge_marked)[3] = (r3d_int (*)[3]) malloc(maxsize*sizeof(r3d_int[3]));
+        for (i = 0; i < maxsize; i++)
+                for (j = 0; j < 3; j++)
+                        edge_marked[i][j] = 0;
 
 	// work arrays
-	r3d_int vtmp[R3D_MAX_VERTS];
-	r3d_int vertincomponent[R3D_MAX_VERTS];
-	r3d_int component_map[R3D_MAX_VERTS];
-	r3d_int numvertsperface[R3D_MAX_VERTS];
-	r3d_int *faceinds[R3D_MAX_VERTS];
-	r3d_brep *breptmp[R3D_MAX_VERTS];	// could be made smaller
+	r3d_int *vtmp = (r3d_int *) malloc(maxsize*sizeof(r3d_int));
+	r3d_int *vertincomponent = (r3d_int *) malloc(maxsize*sizeof(r3d_int));
+	r3d_int *component_map = (r3d_int *) malloc(maxsize*sizeof(r3d_int));
+	r3d_int *numvertsperface = (r3d_int *) malloc(maxsize*sizeof(r3d_int));
+	r3d_int **faceinds = (r3d_int **) malloc(maxsize*sizeof(r3d_int *));
+	r3d_brep **breptmp = (r3d_brep **) malloc(maxsize*sizeof(r3d_brep *));
 
 	// start at the first vertex
 	vstart = 0;
@@ -1112,8 +1253,8 @@ void r3d_init_brep(r3d_poly *poly, r3d_brep **brep, r3d_int *numcomponents) {
 		numvertsincomponent = 0;
 
 		// reset the vertices in the component working array
-		memset(&vertincomponent, 0, sizeof(vertincomponent));
-		memset(&component_map, 0, sizeof(component_map));
+		memset(vertincomponent, 0, maxsize*sizeof(r3d_int));
+		memset(component_map, 0, maxsize*sizeof(r3d_int));
 
 		// iterate faces
 		do {
@@ -1184,6 +1325,10 @@ void r3d_init_brep(r3d_poly *poly, r3d_brep **brep, r3d_int *numcomponents) {
 			numvertsperface[nf] = nvkept;
 			faceinds[nf] = pvind;
 
+			// increment the face counter
+			nf++;
+
+
 			// find the next face
 
 			// to do this, find a vertex in this connected component (marked>0) that
@@ -1195,6 +1340,8 @@ void r3d_init_brep(r3d_poly *poly, r3d_brep **brep, r3d_int *numcomponents) {
 			}
 			vstart = nv;
 
+                        if (nv == nverts) continue;
+                        
 			// find an unwalked edge starting at the this vertex
 			for (np = 0; np < 3; np++) {
 				if (edge_marked[nv][np] == 0) {
@@ -1202,9 +1349,6 @@ void r3d_init_brep(r3d_poly *poly, r3d_brep **brep, r3d_int *numcomponents) {
 				}
 			}
 			pedge = np;
-
-			// increment the face counter
-			nf++;
 
 		} while (nv < nverts);
 
@@ -1285,10 +1429,19 @@ void r3d_init_brep(r3d_poly *poly, r3d_brep **brep, r3d_int *numcomponents) {
 	// at this point, all components have been walked, so we just need to pack up
 	// the brep's from the working array
 	*numcomponents = nc;
-	*brep = (r3d_brep *)malloc(nc * sizeof(r3d_brep));
+	*brep = (r3d_brep **)malloc(nc * sizeof(r3d_brep *));
 	for (i = 0; i < nc; ++i) {
-		brep[i] = breptmp[i];
+          (*brep)[i] = breptmp[i];
 	}
+
+        free(vtmp);
+        free(vertincomponent);
+        free(component_map);
+        free(numvertsperface);
+        free(faceinds);
+        free(breptmp);
+        free(vert_marked);
+        free(edge_marked);
 }
 
 void r3d_print_brep(r3d_brep **brep, r3d_int numcomponents) {
@@ -1336,8 +1489,11 @@ void r3d_free_brep(r3d_brep **brep, r3d_int numcomponents) {
 
 		// free the numvertsperface array
 		free(brep[c]->numvertsperface);
+
+                // free the pointer to the brep
+                free(brep[c]);
 	}
 
-	// freep the top level array of breps
-	free(*brep);
+	// free the array of pointers to breps
+	free(brep);
 }

--- a/r3d.h
+++ b/r3d.h
@@ -93,9 +93,9 @@ typedef struct
  */
 typedef struct
 {
-#define R3D_MAX_VERTS 512
-  r3d_vertex verts[R3D_MAX_VERTS]; /*!< Vertex buffer. */
+  r3d_vertex *verts;               /*!< Vertex buffer. */
   r3d_int nverts;                  /*!< Number of vertices in the buffer. */
+  r3d_int maxverts;
 } r3d_poly;
 
 /**
@@ -115,7 +115,7 @@ int r3d_clip(r3d_poly *poly, r3d_plane *planes, r3d_int nplanes);
 /**
  * \brief Splits a list of polyhedra across a single plane.
  *
- * \param [in] inpolys Array of input polyhedra to be split
+ * \param [in] inpolys Array of input polyhedra to be split (\warning input polyhedra are modified)
  *
  * \param [in] npolys The number of input polyhedra
  *
@@ -280,6 +280,38 @@ void r3d_shear(r3d_poly *poly, r3d_real shear, r3d_int axb, r3d_int axs);
 void r3d_affine(r3d_poly *poly, r3d_real mat[4][4]);
 
 /**
+ * \brief Initialize a empty/blank polyhedron
+ *
+ * \param [out] poly The polyhedron to initialize.
+ *
+ * \param [in] nvalloc Number of vertices we reserve space for
+ *
+ */
+int r3d_init_blank(r3d_poly *poly, r3d_int nvalloc);
+
+/**
+ * \brief Initialize a polygon from another polygon
+ *
+ * \param [out] destpoly The polyhedron to initialize.
+ * \param [in] srcpoly The polyhedron from which to initialize.
+ *
+ * \note memory for vertex buffers in destpoly will be allocated
+ * inside routine as it cannot know if the buffer is allocated or set
+ * to some uninitialized value
+ */
+int r3d_copy(r3d_poly *destpoly, r3d_poly *srcpoly);
+
+/**
+ * \brief Free memory allocated in polyhedron
+ *
+ * \param [in] poly The polyhedron to free
+ *
+ * Behavior is undefined if memory for vertex buffer in polyhedron is
+ * uninitialized
+ */
+void r3d_free(r3d_poly *poly);
+
+/**
  * \brief Initialize a polyhedron as a tetrahedron.
  *
  * \param [out] poly The polyhedron to initialize.
@@ -288,7 +320,7 @@ void r3d_affine(r3d_poly *poly, r3d_real mat[4][4]);
  * tetrahedron.
  *
  */
-void r3d_init_tet(r3d_poly *poly, r3d_rvec3 *verts);
+int r3d_init_tet(r3d_poly *poly, r3d_rvec3 *verts);
 
 /**
  * \brief Initialize a polyhedron as an axis-aligned cube.
@@ -299,7 +331,7 @@ void r3d_init_tet(r3d_poly *poly, r3d_rvec3 *verts);
  * corners of the box.
  *
  */
-void r3d_init_box(r3d_poly *poly, r3d_rvec3 *rbounds);
+int r3d_init_box(r3d_poly *poly, r3d_rvec3 *rbounds);
 
 /**
  * \brief Initialize a general polyhedron from a full boundary description. Can
@@ -393,14 +425,14 @@ typedef struct r3d_brep
  *
  * \param [in] poly Pointer to a single R3D polyhedron.
  *
- * \param [out] brep Pointer to an array of boundary representations that will
- * hold the different boundary representations for the different components.
+ * \param [out] brep Pointer to an array of pointers to boundary representation
+ * (each entry in the array is a pointer to the brep of a polyhedral component)
  *
  * \param [out] numcomponents Pointer to an integer that will hold the number
  * of determined components.
  *
  */
-void r3d_init_brep(r3d_poly *poly, r3d_brep **brep, r3d_int *numcomponents);
+void r3d_init_brep(r3d_poly *poly, r3d_brep ***brep, r3d_int *numcomponents);
 
 
 /**

--- a/test_brep/Makefile
+++ b/test_brep/Makefile
@@ -28,7 +28,7 @@ INC = -I$(R3D_HOME)
 LIB = -L$(R3D_HOME)
 
 # additional link flags
-LDFLAGS = -lr3d -lm
+LDFLAGS = -L$(R3D_HOME) -lr3d -lm
 
 # define the object files
 R3D_OBJ = $(R3D_SRC:.cc=.o)

--- a/test_brep/test_intersection.cc
+++ b/test_brep/test_intersection.cc
@@ -31,7 +31,7 @@ int main() {
 
 #endif
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// planes
@@ -49,22 +49,22 @@ int main() {
 	std::cout << "plane 2 " << plane2.n.xyz[0] << " " << plane2.n.xyz[1] 
 		<< " " << plane2.n.xyz[2] << " " << std::endl;
 
-#endif
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// vertices, It is unlikely we will ever call this directly. It is created
 	// automatically by helper functions like r3d_init_tet
 	//////////////////////////////////////////
 
-	r3d_vertex vertex = {{0, 1., 2}, {5., 6., 7.}};
+	r3d_vertex vertex = {{0, 1, 2}, {5, 6, 7}};
 	std::cout << "vertex " << vertex.pos.x << " " << vertex.pos.y << " "
 		<< vertex.pos.z << " " << std::endl;
 
-#endif
+        }
 
-#if 0
+        {
 	//////////////////////////////////////////
 	// tetrahedron, test clip
 	//////////////////////////////////////////
@@ -85,10 +85,10 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
 	// clip the poly
 	// the definition of the plane is n.v+d=0, which is why d needs to be negative
@@ -99,12 +99,13 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// tetrahedron, test split
@@ -141,9 +142,12 @@ int main() {
 	std::cout << "neg" << std::endl;
 	r3d_print(&out_neg);
 
-#endif
+        r3d_free(&poly);
+        r3d_free(&out_pos);
+        r3d_free(&out_neg);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// make a cube, the easiest way is to make a bound box
@@ -164,14 +168,15 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// make a cube, using the r3d_init_poly interface
@@ -212,14 +217,15 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// make a cube, using the r3d_poly interface with list initialization and
@@ -268,14 +274,15 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// cube, test split
@@ -296,10 +303,10 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
 	// define the plane
 	// the definition of the plane is n.v+d=0, which is why d needs to be negative
@@ -314,8 +321,8 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_init_brep(&out_pos, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 	std::cout << std::endl;
 
 	std::cout << "out_neg" << std::endl;
@@ -323,12 +330,15 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_init_brep(&out_neg, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        r3d_free(&out_pos);
+        r3d_free(&out_neg);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// make a double cube and intersect with a plane so it cuts both cubes
@@ -396,10 +406,10 @@ int main() {
 		<< " and has volume " << volume << std::endl << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
 	// clip in the z normal direction, should be the upper half of two cubes
 	r3d_plane p1 = {{0, 0, 1.}, -.5}; 
@@ -416,12 +426,13 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// make a dimpled cube
@@ -479,10 +490,10 @@ int main() {
 		<< volume << std::endl << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
 	// clip in the z normal direction,
 	r3d_plane p1 = {{0, 0, 1.}, -.5};
@@ -499,12 +510,13 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// make a pyramid with an octagonal base
@@ -555,14 +567,15 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
-#if 0
+        {
 
 	//////////////////////////////////////////
 	// make a double pyramid with an octagonal center
@@ -620,14 +633,15 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
-#if 1
+        {
 
 	//////////////////////////////////////////
 	// make a topological cube with a non-planar top
@@ -677,10 +691,10 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_int numcomponents;
-	r3d_brep *brep;
+	r3d_brep **brep;
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
 	// clip the poly
 	r3d_plane p1 = {{0, 0, 1.}, -.5};
@@ -688,7 +702,7 @@ int main() {
 
 	// get the volume
 	r3d_real volume;
-	r3d_reduce(&poly, &volume, 1);
+	r3d_reduce(&poly, &volume, 0);
 
 	std::cout << "\nclipped poly is good: " << r3d_is_good(&poly)
 		<< " and has volume " << volume << std::endl << std::endl;
@@ -698,10 +712,11 @@ int main() {
 	std::cout << std::endl;
 
 	r3d_init_brep(&poly, &brep, &numcomponents);
-	r3d_print_brep(&brep, numcomponents);
-	r3d_free_brep(&brep, numcomponents);
+	r3d_print_brep(brep, numcomponents);
+	r3d_free_brep(brep, numcomponents);
 
-#endif
+        r3d_free(&poly);
+        }
 
 	return 0;
 }

--- a/tests/rNd_unit_tests.c
+++ b/tests/rNd_unit_tests.c
@@ -234,8 +234,7 @@ void test_moments() {
 	// TODO: just volume for now
 
 	// variables: the polyhedra and their moments
-	rNd_int i;
-	rNd_real tmp, tetvol;
+	rNd_real tetvol;
 	rNd_rvec verts[RND_DIM+1];
 	rNd_poly opoly;
 	rNd_real om[1];
@@ -273,7 +272,7 @@ void test_voxelization() {
 #define NGRID 17 
 
 	// vars
-	rNd_int i, j, k, v, curorder, mind;
+	rNd_int i, v;
 	rNd_long gg; 
 	rNd_int nmom = 1; //R3D_NUM_MOMENTS(POLY_ORDER);
 	rNd_real voxsum, tmom[nmom];

--- a/v3d.c
+++ b/v3d.c
@@ -46,6 +46,7 @@
 #include <string.h>
 #include <math.h>
 #include <stdint.h>
+#include <stdio.h>
 
 #define wav(va, wa, vb, wb, vr) {			\
 	vr.x = (wa*va.x + wb*vb.x)/(wa + wb);	\
@@ -54,9 +55,9 @@
 }
 
 // TODO: make this a generic "split" routine that just takes a plane.
-void r3d_split_coord(r3d_poly* inpoly, r3d_poly** outpolys, r3d_real coord, r3d_int ax);
+int r3d_split_coord(r3d_poly* inpoly, r3d_poly** outpolys, r3d_real coord, r3d_int ax);
 
-void r3d_voxelize(r3d_poly* poly, r3d_dvec3 ibox[2], r3d_real* dest_grid, r3d_rvec3 d, r3d_int polyorder) {
+int r3d_voxelize(r3d_poly* poly, r3d_dvec3 ibox[2], r3d_real* dest_grid, r3d_rvec3 d, r3d_int polyorder) {
 
 	r3d_int i, m, spax, dmax, nstack, siz;
 	r3d_int nmom = R3D_NUM_MOMENTS(polyorder);
@@ -67,20 +68,21 @@ void r3d_voxelize(r3d_poly* poly, r3d_dvec3 ibox[2], r3d_real* dest_grid, r3d_rv
 	// return if any parameters are bad 
 	for(i = 0; i < 3; ++i) gridsz.ijk[i] = ibox[1].ijk[i]-ibox[0].ijk[i];	
 	if(!poly || poly->nverts <= 0 || !dest_grid || 
-			gridsz.i <= 0 || gridsz.j <= 0 || gridsz.k <= 0) return;
+			gridsz.i <= 0 || gridsz.j <= 0 || gridsz.k <= 0) return 0;
 	
 	// explicit stack-based implementation
 	// stack size should never overflow in this implementation, 
 	// even for large input grids (up to ~512^3) 
 	struct {
-		r3d_poly poly;
+		r3d_poly *poly;
 		r3d_dvec3 ibox[2];
 	} stack[(r3d_int)(ceil(log2(gridsz.i))+ceil(log2(gridsz.j))+ceil(log2(gridsz.k))+1)];
 
 	// push the original polyhedron onto the stack
 	// and recurse until child polyhedra occupy single voxels
 	nstack = 0;
-	stack[nstack].poly = *poly;
+	stack[nstack].poly = (r3d_poly *) malloc(sizeof(r3d_poly));
+        r3d_copy(stack[nstack].poly, poly);
 	memcpy(stack[nstack].ibox, ibox, 2*sizeof(r3d_dvec3));
 	nstack++;
 	while(nstack > 0) {
@@ -88,7 +90,11 @@ void r3d_voxelize(r3d_poly* poly, r3d_dvec3 ibox[2], r3d_real* dest_grid, r3d_rv
 		// pop the stack
 		// if the leaf is empty, skip it
 		--nstack;
-		if(stack[nstack].poly.nverts <= 0) continue;
+		if(stack[nstack].poly->nverts <= 0) {
+                  r3d_free(stack[nstack].poly);
+                  free(stack[nstack].poly);
+                  continue;
+                }
 		
 		// find the longest axis along which to split 
 		dmax = 0;
@@ -104,39 +110,53 @@ void r3d_voxelize(r3d_poly* poly, r3d_dvec3 ibox[2], r3d_real* dest_grid, r3d_rv
 		// if all three axes are only one voxel long, reduce the single voxel to the dest grid
 #define gind(ii, jj, kk, mm) (nmom*((ii-ibox[0].i)*gridsz.j*gridsz.k+(jj-ibox[0].j)*gridsz.k+(kk-ibox[0].k))+mm)
 		if(dmax == 1) {
-			r3d_reduce(&stack[nstack].poly, moments, polyorder);
+			r3d_reduce(stack[nstack].poly, moments, polyorder);
 			// TODO: cell shifting for accuracy
 			for(m = 0; m < nmom; ++m)
 				dest_grid[gind(stack[nstack].ibox[0].i, stack[nstack].ibox[0].j, 
 						stack[nstack].ibox[0].k, m)] += moments[m];
+                        r3d_free(stack[nstack].poly);
+                        free(stack[nstack].poly);
 			continue;
 		}
 
 		// split the poly and push children to the stack
-		children[0] = &stack[nstack].poly;
-		children[1] = &stack[nstack+1].poly;
-		r3d_split_coord(&stack[nstack].poly, children, d.xyz[spax]*(stack[nstack].ibox[0].ijk[spax]+dmax/2), spax);
+		int success = r3d_split_coord(stack[nstack].poly, children, d.xyz[spax]*(stack[nstack].ibox[0].ijk[spax]+dmax/2), spax);
+                if (!success) return 0;
+
+                // We are going to overwrite this poly
+                r3d_free(stack[nstack].poly);
+                free(stack[nstack].poly);
+                
+                stack[nstack].poly = children[0];
+                stack[nstack+1].poly = children[1];
 		memcpy(stack[nstack+1].ibox, stack[nstack].ibox, 2*sizeof(r3d_dvec3));
 		stack[nstack].ibox[1].ijk[spax] -= dmax-dmax/2; 
 		stack[nstack+1].ibox[0].ijk[spax] += dmax/2;
 		nstack += 2;
 	}
+
+        return 1;
 }
 
-void r3d_split_coord(r3d_poly* inpoly, r3d_poly** outpolys, r3d_real coord, r3d_int ax) {
+int r3d_split_coord(r3d_poly* inpoly, r3d_poly** outpolys, r3d_real coord, r3d_int ax) {
 
 	// direct access to vertex buffer
-	if(inpoly->nverts <= 0) return;
+	if(inpoly->nverts <= 0) return 0;
 	r3d_int* nverts = &inpoly->nverts;
+        r3d_int* maxverts = &inpoly->maxverts;
 	r3d_vertex* vertbuffer = inpoly->verts; 
 	r3d_int v, np, npnxt, onv, vcur, vnext, vstart, pnext, nright, cside;
 	r3d_rvec3 newpos;
-	r3d_int side[R3D_MAX_VERTS];
-	r3d_real sdists[R3D_MAX_VERTS];
+	r3d_int *side = (r3d_int *) calloc(*nverts, sizeof(r3d_int));
+	r3d_real *sdists = (r3d_real *) calloc(*nverts, sizeof(r3d_real));
+
+        outpolys[0] = (r3d_poly *) malloc(sizeof(r3d_poly));
+        outpolys[1] = (r3d_poly *) malloc(sizeof(r3d_poly));
 
 	// calculate signed distances to the clip plane
 	nright = 0;
-	memset(&side, 0, sizeof(side));
+	memset(side, 0, *nverts*sizeof(r3d_int));
 	for(v = 0; v < *nverts; ++v) {
 		sdists[v] = vertbuffer[v].pos.xyz[ax] - coord;
 		if(sdists[v] > 0.0) {
@@ -147,14 +167,18 @@ void r3d_split_coord(r3d_poly* inpoly, r3d_poly** outpolys, r3d_real coord, r3d_
 
 	// return if the poly lies entirely on one side of it 
 	if(nright == 0) {
-		*(outpolys[0]) = *inpoly;
-		outpolys[1]->nverts = 0;
-		return;
+                r3d_copy(outpolys[0], inpoly);
+		r3d_init_blank(outpolys[1], 0);
+                free(side);
+                free(sdists);
+		return 1;
 	}
 	if(nright == *nverts) {
-		*(outpolys[1]) = *inpoly;
-		outpolys[0]->nverts = 0;
-		return;
+                r3d_copy(outpolys[1], inpoly);
+		r3d_init_blank(outpolys[0], 0);
+                free(side);
+                free(sdists);
+		return 1;
 	}
 
 	// check all edges and insert new vertices on the bisected edges 
@@ -167,16 +191,31 @@ void r3d_split_coord(r3d_poly* inpoly, r3d_poly** outpolys, r3d_real coord, r3d_
 			wav(vertbuffer[vcur].pos, -sdists[vnext],
 				vertbuffer[vnext].pos, sdists[vcur],
 				newpos);
+
+                        if (*nverts == *maxverts) {
+                                vertbuffer = (r3d_vertex *) realloc(vertbuffer, 2*(*maxverts)*sizeof(r3d_vertex));
+                                inpoly->verts = vertbuffer;
+                                if (!vertbuffer) return 0;
+                                side = (r3d_int *) realloc(side, 2*(*maxverts)*sizeof(r3d_int));
+                                
+                                if (!side) return 0;
+                                memset(side + *maxverts, 0, *maxverts*sizeof(r3d_int));
+                                *maxverts *= 2;
+                        }
+
 			vertbuffer[*nverts].pos = newpos;
 			vertbuffer[*nverts].pnbrs[0] = vcur;
 			vertbuffer[vcur].pnbrs[np] = *nverts;
 			(*nverts)++;
+
 			vertbuffer[*nverts].pos = newpos;
 			side[*nverts] = 1;
+                        nright++;
 			vertbuffer[*nverts].pnbrs[0] = vnext;
 			for(npnxt = 0; npnxt < 3; ++npnxt) 
 				if(vertbuffer[vnext].pnbrs[npnxt] == vcur) break;
 			vertbuffer[vnext].pnbrs[npnxt] = *nverts;
+
 			(*nverts)++;
 		}
 	}
@@ -199,8 +238,8 @@ void r3d_split_coord(r3d_poly* inpoly, r3d_poly** outpolys, r3d_real coord, r3d_
 	// copy and compress vertices into their new buffers
 	// reusing side[] for reindexing
 	onv = *nverts;
-	outpolys[0]->nverts = 0;
-	outpolys[1]->nverts = 0;
+        r3d_init_blank(outpolys[0], *nverts-nright);
+        r3d_init_blank(outpolys[1], nright);
 	for(v = 0; v < onv; ++v) {
 		cside = side[v];
 		outpolys[cside]->verts[outpolys[cside]->nverts] = vertbuffer[v];
@@ -213,6 +252,10 @@ void r3d_split_coord(r3d_poly* inpoly, r3d_poly** outpolys, r3d_real coord, r3d_
 	for(v = 0; v < outpolys[1]->nverts; ++v) 
 		for(np = 0; np < 3; ++np)
 			outpolys[1]->verts[v].pnbrs[np] = side[outpolys[1]->verts[v].pnbrs[np]];
+
+        free(side);
+        free(sdists);
+        return 1;
 }
 
 void r3d_get_ibox(r3d_poly* poly, r3d_dvec3 ibox[2], r3d_rvec3 d) {

--- a/v3d.h
+++ b/v3d.h
@@ -82,7 +82,7 @@ extern "C" {
  * 0 for constant (1 moment), 1 for linear (4 moments), 2 for quadratic (10 moments), etc.
  *
  */
-void r3d_voxelize(r3d_poly* poly, r3d_dvec3 ibox[2], r3d_real* dest_grid, r3d_rvec3 d, r3d_int polyorder);
+int r3d_voxelize(r3d_poly* poly, r3d_dvec3 ibox[2], r3d_real* dest_grid, r3d_rvec3 d, r3d_int polyorder);
 
 /**
  * \brief Get the minimal box of grid indices for a polyhedron, given a grid cell spacing,


### PR DESCRIPTION
This PR changes the `r3d_poly` data structure to use a dynamically allocated array instead of a static one dependent on `R3D_MAX_VERTS` to address the issue raised in #15.

 This **does** change the usage pattern of the `r3d_poly` data structure though. Now, a simple `r3d_poly` declaration is not enough because the `vertbuffer` will not be allocated. Instead, an `r3d_poly` needs to be initialized using one of the `r3d_init_*` routines (including a new one called `r3d_init_blank`). Also, the calling application must explicitly invoke `r3d_free` to free up the memory associated with `vertbuffer`. Finally, instead of being able to assign one r3d_poly to another, the user must explicitly invoke the `r3d_copy` routine. So, users have to be warned about that.

There is also now an inconsistency between r3d_poly and r2d_poly interfaces.

It also contains a fix/change to the r3d_init_brep interface. Previously, this took in `r3d_poly **` but it needs to take `r3d_poly ***`.

I tested these changes thoroughly - I ran all the unit tests in R3D through valgrind and eliminated any memory errors or leaks. For the tests, the time of the new code increased slightly (24s -> 27s) and memory dropped from 15600 to 8300 with execution time increasing from 22s to 27s.
I also incorporated the code into Portage and Tangram and tested it as best I could with and without valgrind which it passes. However in Portage, the advantage is not so clear - probably the size of the mesh overwhelms any increased memory savings from the new R3D.

So, the question becomes - do we just increase the buffer size to 1024 and call it a day or incorporate these changes.

