### PR TITLE
r3dConfig.cmake changes

### DIFF
--- a/config/r3dConfig.cmake.in
+++ b/config/r3dConfig.cmake.in
@@ -3,7 +3,7 @@
 #-----------------------------------------------------------------------------
 
 # Compiler Definitions
-set(CMAKE_C_COMPILER @CMAKE_C_COMPILER@ CACHE FILEPATH "C Compiler used for compiling R3D")
+set(r3d_C_COMPILER @CMAKE_C_COMPILER@ CACHE FILEPATH "C Compiler used for compiling R3D")
 
 # R3D installation path
 set(r3d_ROOT @CMAKE_INSTALL_PREFIX@ CACHE PATH "Path to R3D installation")
@@ -16,16 +16,6 @@ set(r3d_INCLUDE_DIR @CMAKE_INSTALL_PREFIX@/include CACHE PATH "R3D include file 
 
 # R3D options
 set(R3D_MAX_VERTS @R3D_MAX_VERTS@ CACHE STRING "Max verts in R3D polyhedron")
-
-
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.12)
-  cmake_policy(SET CMP0074 NEW)  # find_package honors Pkg_ROOT variables 
-endif ()
-
-if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.15)
-  set(CMAKE_FIND_PACKAGE_PREFER_CONFIG TRUE)  # search for PkgConfig.cmake files first
-endif ()
-
 
 #
 # Import R3D targets


### PR DESCRIPTION
do not set CMAKE_C_COMPILER; remove policy settings - since r3D is not importing any dependencies, we don't need them