### PR TITLE
making shifting polytops for moment calculation optional in CMake

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -38,6 +38,10 @@ These tests also serve as examples of how to use `r3d`.
   -DR3D_MAX_VERTS=N ..`). This autogenerates a config file
   `r3d-config.h` at build time which is included in `r3d.h`. (Note: This makes it impossible to use a simple Makefile to compile R3D)
 
+- To improve accuracy of moment calculations, polytops can be shifted to the origin by
+  setting -DSHIFT_POLY=True in CMake configuration options. This option is particularly
+  beneficial for small polytops located far from the origin, but it is computationally
+  costly for high-order moments.
 
 ---
 

--- a/config/r3d-config.h.in
+++ b/config/r3d-config.h.in
@@ -6,4 +6,6 @@
 
 #define R3D_MAX_VERTS @R3D_MAX_VERTS@
 
+#define SHIFT_POLY @SHIFT_POLY@
+
 #endif

--- a/config/r3dConfig.cmake.in
+++ b/config/r3dConfig.cmake.in
@@ -17,6 +17,8 @@ set(r3d_INCLUDE_DIR @CMAKE_INSTALL_PREFIX@/include CACHE PATH "R3D include file 
 # R3D options
 set(R3D_MAX_VERTS @R3D_MAX_VERTS@ CACHE STRING "Max verts in R3D polyhedron")
 
+set(SHIFT_POLY @SHIFT_POLY@ CACHE STRING "Enable shifting of polytops for moment calculation")
+
 #
 # Import R3D targets
 #

--- a/src/r2d.c
+++ b/src/r2d.c
@@ -242,11 +242,11 @@ void r2d_reduce(r2d_poly* poly, r2d_real* moments, r2d_int polyorder) {
 
 	if(*nverts <= 0) return;
 
-	// flag to translate a polygon to the origin for increased accuracy
+#ifdef SHIFT_POLY
+	// translate a polygon to the origin for increased accuracy
 	// (this will increase computational cost, in particular for higher moments)
-	r2d_int shift_poly = 1;
-
-	if(shift_poly) vc = r2d_poly_center(poly);
+	vc = r2d_poly_center(poly);
+#endif
 
 	// Storage for coefficients
 	// keep two layers of the triangle of coefficients
@@ -262,12 +262,12 @@ void r2d_reduce(r2d_poly* poly, r2d_real* moments, r2d_int polyorder) {
 		v0 = vertbuffer[vcur].pos;
 		v1 = vertbuffer[vnext].pos;
 
-		if(shift_poly) {
-			v0.x = v0.x - vc.x;
-			v0.y = v0.y - vc.y;
-			v1.x = v1.x - vc.x;
-			v1.y = v1.y - vc.y;
-		}
+#ifdef SHIFT_POLY
+		v0.x = v0.x - vc.x;
+		v0.y = v0.y - vc.y;
+		v1.x = v1.x - vc.x;
+		v1.y = v1.y - vc.y;
+#endif
 
 		twoa = (v0.x*v1.y - v0.y*v1.x);
 
@@ -316,8 +316,9 @@ void r2d_reduce(r2d_poly* poly, r2d_real* moments, r2d_int polyorder) {
 		prevlayer = 1 - prevlayer;
 	}
 
-	if(shift_poly) r2d_shift_moments(moments, polyorder, vc);
-
+#ifdef SHIFT_POLY
+	r2d_shift_moments(moments, polyorder, vc);
+#endif
 }
 
 void r2d_shift_moments(r2d_real* moments, r2d_int polyorder, r2d_rvec2 vc) {

--- a/src/r3d.c
+++ b/src/r3d.c
@@ -267,11 +267,11 @@ void r3d_reduce(r3d_poly *poly, r3d_real *moments, r3d_int polyorder) {
 
 	if (*nverts <= 0) return;
 
-	// flag to translate a polyhedron to the origin for increased accuracy
+#ifdef SHIFT_POLY
+	// translate a polyhedron to the origin for increased accuracy
 	// (this will increase computational cost, in particular for higher moments)
-	r3d_int shift_poly = 1;
-
-	if(shift_poly) vc = r3d_poly_center(poly);
+	vc = r3d_poly_center(poly);
+#endif
 
 	// for keeping track of which edges have been visited
 	r3d_int emarks[*nverts][3];
@@ -298,11 +298,11 @@ void r3d_reduce(r3d_poly *poly, r3d_real *moments, r3d_int polyorder) {
 			vnext = vertbuffer[vcur].pnbrs[pnext];
 			v0 = vertbuffer[vcur].pos;
 
-			if(shift_poly) {
-				v0.x = v0.x - vc.x;
-				v0.y = v0.y - vc.y;
-				v0.z = v0.z - vc.z;
-			}
+#ifdef SHIFT_POLY
+			v0.x = v0.x - vc.x;
+			v0.y = v0.y - vc.y;
+			v0.z = v0.z - vc.z;
+#endif
 
 			// move to the second edge
 			for (np = 0; np < 3; ++np)
@@ -317,14 +317,14 @@ void r3d_reduce(r3d_poly *poly, r3d_real *moments, r3d_int polyorder) {
 				v2 = vertbuffer[vcur].pos;
 				v1 = vertbuffer[vnext].pos;
 
-				if(shift_poly) {
-					v2.x = v2.x - vc.x;
-					v2.y = v2.y - vc.y;
-					v2.z = v2.z - vc.z;
-					v1.x = v1.x - vc.x;
-					v1.y = v1.y - vc.y;
-					v1.z = v1.z - vc.z;
-				}
+#ifdef SHIFT_POLY
+				v2.x = v2.x - vc.x;
+				v2.y = v2.y - vc.y;
+				v2.z = v2.z - vc.z;
+				v1.x = v1.x - vc.x;
+				v1.y = v1.y - vc.y;
+				v1.z = v1.z - vc.z;
+#endif
 
 				sixv = (-v2.x * v1.y * v0.z + v1.x * v2.y * v0.z + v2.x * v0.y * v1.z -
 								v0.x * v2.y * v1.z - v1.x * v0.y * v2.z + v0.x * v1.y * v2.z);
@@ -396,8 +396,9 @@ void r3d_reduce(r3d_poly *poly, r3d_real *moments, r3d_int polyorder) {
 		prevlayer = 1 - prevlayer;
 	}
 
-	if(shift_poly) r3d_shift_moments(moments, polyorder, vc);
-
+#ifdef SHIFT_POLY
+	r3d_shift_moments(moments, polyorder, vc);
+#endif
 }
 
 void r3d_shift_moments(r3d_real* moments, r3d_int polyorder, r3d_rvec3 vc) {


### PR DESCRIPTION
This allows the control of a shift_moment option from CMake. We want to make this optional since our user code does shifting of polytopes itself and there is no benefit of doing this shift twice.

Note that this PR changes the default code behavior to NOT shift. If this is a problem, I can change the logic to maintain current functionality by default. 